### PR TITLE
Some minor refactors.

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ schemaVersion: 2.2.0
 attributes:
   controller.devfile.io/storage-type: per-workspace
 metadata:
-  name: nested-containers-demo
+  name: ansible-devspaces-example
 components:
   - name: dev-tools
     attributes:
@@ -27,6 +27,9 @@ components:
       cpuRequest: 250m
       memoryLimit: 4Gi
       memoryRequest: 128Mi
+      env:
+        - name: VSCODE_DEFAULT_WORKSPACE
+          value: /projects/devspaces-example/devspaces.code-workspace
   - name: prep-workspace
     container:
       args:

--- a/devspaces.code-workspace
+++ b/devspaces.code-workspace
@@ -1,0 +1,47 @@
+{
+    "folders": [
+        {
+            "name": "devspaces-example",
+            "path": "/projects/devspaces-example"
+        }
+    ],
+    "extensions": {
+        "recommendations": [
+            "redhat.vscode-yaml",
+            "ms-python.python",
+            "redhat.ansible",
+            "redhat.vscode-openshift-connector",
+            "ms-python.black-formatter"
+        ]
+    },
+    "settings": {
+        "editor.wordWrap": "on",
+        "files.associations": {
+            "*.yml": "ansible"
+        },
+        "ansible.ansible.path": "/usr/local/bin/ansible",
+        "ansible.python.interpreterPath": "/usr/bin/python3",
+        "ansible.ansible.useFullyQualifiedCollectionNames": true,
+        "ansible.ansibleNavigator.path": "/usr/local/bin/ansible-navigator",
+        "ansible.completion.provideModuleOptionAliases": true,
+        "ansible.completion.provideRedirectModules": true,
+        "ansible.validation.enabled": true,
+        "ansible.validation.lint.enabled": true,
+        "ansible.validation.lint.path": "/usr/local/bin/ansible-lint",
+        "files.trimTrailingWhitespace": true,
+        "files.trimFinalNewlines": true,
+        "files.insertFinalNewline": true,
+        "ansible.validation.lint.arguments": "--profile production --offline",
+        "[python]": {
+            "editor.defaultFormatter": "ms-python.black-formatter"
+        },
+        "redhat.telemetry.enabled": true,
+        "ansible.executionEnvironment.containerEngine": "podman",
+        "git.autofetch": true,
+        "ansible.lightspeed.enabled": false,
+        "terminal.integrated.scrollback": 10000,
+        "openshiftToolkit.showWelcomePage": false,
+        "openshiftToolkit.searchForToolsInPath": true,
+        "openshiftToolkit.execMaxBufferLength": 10
+    }
+}

--- a/workspace-config/vscode-configmap.yaml
+++ b/workspace-config/vscode-configmap.yaml
@@ -6,48 +6,6 @@ metadata:
      app.kubernetes.io/part-of: che.eclipse.org
      app.kubernetes.io/component: workspaces-config
 data:
-  extensions.json: |
-    {
-      "recommendations": [
-          "redhat.vscode-yaml",
-          "ms-python.python",
-          "redhat.ansible",
-          "redhat.vscode-openshift-connector",
-          "ms-python.black-formatter"
-      ]
-    }
-  settings.json: |
-    {
-      "editor.wordWrap": "on",
-      "files.associations": {
-          "*.yml": "ansible"
-        },
-      "ansible.ansible.path": "/usr/local/bin/ansible",
-      "ansible.python.interpreterPath": "/usr/bin/python3",
-      "ansible.ansible.useFullyQualifiedCollectionNames": true,
-      "ansible.ansibleNavigator.path": "/usr/local/bin/ansible-navigator",
-      "ansible.completion.provideModuleOptionAliases": true,
-      "ansible.completion.provideRedirectModules": true,
-      "ansible.validation.enabled": true,
-      "ansible.validation.lint.enabled": true,
-      "ansible.validation.lint.path": "/usr/local/bin/ansible-lint",
-      "files.trimTrailingWhitespace": true,
-      "files.trimFinalNewlines": true,
-      "files.insertFinalNewline": true,
-      "ansible.validation.lint.arguments": "--profile production --offline",
-      "[python]": {
-          "editor.defaultFormatter": "ms-python.black-formatter"
-      },
-      "redhat.telemetry.enabled": true,
-      "ansible.executionEnvironment.containerEngine": "podman",
-      "git.autofetch": true,
-      "ansible.lightspeed.enabled": false,
-      "terminal.integrated.scrollback": 10000,
-      "openshiftToolkit.showWelcomePage": false,
-      "openshiftToolkit.searchForToolsInPath": true,
-      "openshiftToolkit.execMaxBufferLength": 10
-
-    }
   configurations.json: |
     {
       "extensions.install-from-vsix-enabled": false

--- a/workspace-image/Containerfile
+++ b/workspace-image/Containerfile
@@ -41,5 +41,6 @@ RUN mkdir -p ${USER_HOME_DIR} ; \
     setcap cap_setgid+ep /usr/bin/newgidmap ; \
     chmod +x /entrypoint.sh
 
+USER 1000
 ENTRYPOINT ["/usr/libexec/podman/catatonit","--","/entrypoint.sh"]
 CMD [ "tail", "-f", "/dev/null" ]

--- a/workspace-image/Containerfile
+++ b/workspace-image/Containerfile
@@ -1,7 +1,5 @@
-
 FROM registry.access.redhat.com/ubi9
 ARG USER_HOME_DIR="/home/user"
-ARG WORK_DIR="/projects"
 
 ENV HOME=${USER_HOME_DIR} \
     BUILDAH_ISOLATION=chroot \
@@ -31,13 +29,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 #
 # Setup for root-less podman
 #
-RUN setcap cap_setuid+ep /usr/bin/newuidmap ; \
+RUN mkdir -p ${USER_HOME_DIR} ; \
+    mkdir -p ${USER_HOME_DIR}/.config/containers ; \
+    (echo '[storage]';echo 'driver = "overlay"';echo 'graphroot = "/tmp/graphroot"';echo '[storage.options.overlay]';echo 'mount_program = "/usr/bin/fuse-overlayfs"') > ${USER_HOME_DIR}/.config/containers/storage.conf ; \
+    chown -R 1000:1000 ${USER_HOME_DIR} ; \
+    echo "user:x:1000:0:devspaces user:${USER_HOME_DIR}:/bin/bash" >> /etc/passwd ; \
+    echo "user:x:1000:" >> /etc/group ; \
+    echo "user:1001:64535" >> /etc/subuid ; \
+    echo "user:1001:64535" >> /etc/subgid ; \
+    setcap cap_setuid+ep /usr/bin/newuidmap ; \
     setcap cap_setgid+ep /usr/bin/newgidmap ; \
-    touch /etc/subgid /etc/subuid ; \
-    chown 0:0 /etc/passwd /etc/group /etc/subuid /etc/subgid ; \
-    chmod -R g=u /etc/passwd /etc/group /etc/subuid /etc/subgid /home ${WORK_DIR} ; \
     chmod +x /entrypoint.sh
 
-WORKDIR ${WORK_DIR}
 ENTRYPOINT ["/usr/libexec/podman/catatonit","--","/entrypoint.sh"]
 CMD [ "tail", "-f", "/dev/null" ]

--- a/workspace-image/entrypoint.sh
+++ b/workspace-image/entrypoint.sh
@@ -5,18 +5,4 @@ then
   mkdir -p "${HOME}"
 fi
 
-if ! whoami &> /dev/null
-then
-  if [ -w /etc/passwd ]
-  then
-    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
-    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
-  fi
-fi
-USER=$(whoami)
-START_ID=$(( $(id -u)+1 ))
-END_ID=$(( 65536-${START_ID} ))
-echo "${USER}:${START_ID}:${END_ID}" > /etc/subuid
-echo "${USER}:${START_ID}:${END_ID}" > /etc/subgid
-
 exec "$@"


### PR DESCRIPTION
1. Explicitly build the workspace container image to run as user 1000.  This eliminates the need to make `/etc/...` writable.  It also eliminates the need for user configuration logic in the entry point for the container.
2. Move the recommended VS Code settings and Extensions to a code-workspace file.  Using the ConfigMap to distribute settings prevents users from customizing their VS Code environment.
3. Configure the Devfile to open the workspace defined in the code-workspace file.